### PR TITLE
Add start goal pose sample method in PathPlanner

### DIFF
--- a/examples/1_1_sample_start_goal.py
+++ b/examples/1_1_sample_start_goal.py
@@ -1,0 +1,69 @@
+import os
+import sys
+from datetime import datetime
+
+import numpy as np
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+
+from path_planners.utils.gridmap_utils import load_occupancy_map_by_config_path
+from path_planners.utils.plot_utils import plot_occupancy_grid, plot_global_path
+from path_planners.rrt_star_smooth_unicycle import RrtStarSmoothUnicyclePlanner
+
+
+# fix seed
+np.random.seed()
+
+if __name__ == "__main__":
+    map_name = "World0"  # "World0", "test_occupancy_map_0"
+    yaml_file_path = os.path.join(
+        os.path.dirname(__file__), "../occupancy_maps/" + map_name + ".yaml"
+    )
+    occupancy_map, occupancy_map_resolution, occupancy_map_origin = (
+        load_occupancy_map_by_config_path(yaml_file_path, flip_y_axis=True)
+    )
+
+    print("occupancy_map.shape", occupancy_map.shape)
+    # plot_occupancy_grid(occupancy_map, resolution, origin)
+
+    rrt_unicycle_config = {
+        "terminate_on_goal_reached": False,
+        "interpolate_path": True,
+        "d_s": 0.5,
+        "goal_reach_dist_threshold": 0.5,
+        "goal_reach_angle_threshold": 0.1 * np.pi,
+        "occupancy_map_obstacle_padding_dist": 0.5,
+        "goal_sample_rate": 0.1,
+        "max_iter": int(14000),
+        "max_drive_dist": 0.5,
+        "linear_velocity": 1.0,
+        "max_angular_velocity": 2.0,
+        "near_node_dist_threshold": 1.0,
+    }
+
+    rrt_unicycle_path_planner = RrtStarSmoothUnicyclePlanner(
+        **rrt_unicycle_config, render_tree_during_planning=False
+    )
+
+    rrt_unicycle_path_planner.set_occupancy_map(
+        occupancy_map,
+        occupancy_map_resolution,
+        occupancy_map_origin,
+    )
+
+    start_pose, goal_pose = rrt_unicycle_path_planner.sample_start_goal_poses(
+        min_dist=5.0
+    )
+
+    print("start_pose", start_pose)
+    print("goal_pose", goal_pose)
+
+    plot_global_path(
+        occupancy_map,
+        occupancy_map_resolution,
+        occupancy_map_origin,
+        start_pose,
+        goal_pose,
+        [],
+    )

--- a/path_planners/path_planner.py
+++ b/path_planners/path_planner.py
@@ -110,7 +110,9 @@ class PathPlanner:
         self, min_dist: float = 1.0
     ) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
         """
-        Sample start and goal poses
+        Sample start and goal poses.
+        Poses are sampled in collision free region considering the padding distance.
+        Yaw is sampled from (-pi, pi].
         """
         if min_dist >= np.linalg.norm(
             [self._x_max - self._x_min, self._y_max - self._y_min]
@@ -120,10 +122,12 @@ class PathPlanner:
             )
 
         while True:
-            start_pose = self._sample_random_collision_free_pos()
-            goal_pose = self._sample_random_collision_free_pos()
-            if MathUtils.calculate_dist(start_pose[:2], goal_pose[:2]) >= min_dist:
+            start_pos = self._sample_random_collision_free_pos()
+            goal_pos = self._sample_random_collision_free_pos()
+            if MathUtils.calculate_dist(start_pos[:2], goal_pos[:2]) >= min_dist:
                 break
+        start_pose = (*start_pos, -np.random.uniform(-np.pi, np.pi))
+        goal_pose = (*goal_pos, -np.random.uniform(-np.pi, np.pi))
         return start_pose, goal_pose
 
     def _plan_path(

--- a/path_planners/path_planner.py
+++ b/path_planners/path_planner.py
@@ -5,6 +5,7 @@ import numpy as np
 import path_planners.utils.geometry_utils as GeometryUtils
 import path_planners.utils.gridmap_utils as GridmapUtils
 import path_planners.utils.plot_utils as PlotUtils
+import path_planners.utils.math_utils as MathUtils
 
 
 class PathPlanner:
@@ -105,6 +106,26 @@ class PathPlanner:
 
         return success, path, num_nodes_sampled
 
+    def sample_start_goal_poses(
+        self, min_dist: float = 1.0
+    ) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
+        """
+        Sample start and goal poses
+        """
+        if min_dist >= np.linalg.norm(
+            [self._x_max - self._x_min, self._y_max - self._y_min]
+        ):
+            raise ValueError(
+                "The minimum distance between start and goal poses should be less than the map size!"
+            )
+
+        while True:
+            start_pose = self._sample_random_collision_free_pos()
+            goal_pose = self._sample_random_collision_free_pos()
+            if MathUtils.calculate_dist(start_pose[:2], goal_pose[:2]) >= min_dist:
+                break
+        return start_pose, goal_pose
+
     def _plan_path(
         self,
         start_pose: Tuple[float, float, float],
@@ -154,6 +175,20 @@ class PathPlanner:
             np.random.uniform(self._x_min, self._x_max),
             np.random.uniform(self._y_min, self._y_max),
         )
+
+    def _sample_random_collision_free_pos(self) -> Tuple[float, float, float]:
+        """
+        Sample a random position that is obstacle free.
+        """
+        while True:
+            pos = self._sample_random_pos()
+            if GridmapUtils.check_if_pos_is_free(
+                self._padded_occupancy_map,
+                self._occupancy_map_resolution,
+                self._occupancy_map_origin,
+                pos,
+            ):
+                return pos
 
     def _interpolate_poses_on_path(
         self, path: List[Tuple[float, float, float]]

--- a/path_planners/utils/math_utils.py
+++ b/path_planners/utils/math_utils.py
@@ -1,4 +1,17 @@
+from typing import Tuple
+import math
+
 import numpy as np
+
+
+def calculate_dist(pos_i: Tuple[float, float], pos_f: Tuple[float, float]) -> float:
+    """
+    Calculate the distance between the two positions
+    """
+    return math.sqrt(
+        (pos_i[0] - pos_f[0]) * (pos_i[0] - pos_f[0])
+        + (pos_i[1] - pos_f[1]) * (pos_i[1] - pos_f[1])
+    )
 
 
 def normalize_angle(angle: float) -> float:

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -1,6 +1,17 @@
 import numpy as np
 
-from path_planners.utils.math_utils import normalize_angle, normalize_angle_positive
+from path_planners.utils.math_utils import (
+    calculate_dist,
+    normalize_angle,
+    normalize_angle_positive,
+)
+
+
+def test_calculate_dist():
+    assert calculate_dist((0.0, 0.0), (0.0, 0.0)) == 0.0
+    assert calculate_dist((0.0, 0.0), (1.0, 0.0)) == 1.0
+    assert calculate_dist((0.0, 0.0), (0.0, 1.0)) == 1.0
+    assert calculate_dist((0.0, 0.0), (1.0, 1.0)) == np.sqrt(2.0)
 
 
 def test_normalize_angle():


### PR DESCRIPTION
# Summary
Add start goal pose sample method in PathPlanner

# Changes
Add sample_start_goal_poses(min_dist) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]: method to PathPlanner class.
- It samples start and goal poses from collision free region.
# Results
`python examples/1_1_sample_start_goal.py`
![start_goal_sample](https://github.com/user-attachments/assets/6f03ba65-ebe9-4f54-a3a1-31b54b68f19f)
